### PR TITLE
feat: update helm chart installation to use OCI registry

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -104,9 +104,6 @@ jobs:
       - name: Run e2e with chart
         if: steps.ct-test.outputs.ct_tested == 'true'
         run: |
-          # Add kubedoop helm repo
-          helm repo add kubedoop https://zncdatadev.github.io/kubedoop-helm-charts/
-
           HELM_DEPENDENCIES=(
             commons-operator
             listener-operator
@@ -115,7 +112,7 @@ jobs:
 
           # Install dependencies
           for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep kubedoop/$dep
+            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
           done
 
           # Install spark-k8s-operator chart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,7 +293,7 @@ jobs:
 
           # Install dependencies
           for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep kubedoop/$dep
+            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
           done
 
           # Install spark-k8s-operator chart

--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ helm-install-depends: helm ## Install the helm chart depends.
 	$(HELM) repo add kubedoop https://zncdatadev.github.io/kubedoop-helm-charts/
 ifneq ($(strip $(HELM_DEPENDS)),)
 	for dep in $(HELM_DEPENDS); do \
-		$(HELM) upgrade --install --create-namespace --namespace $(TEST_NAMESPACE) --wait $$dep kubedoop/$$dep --version $(VERSION); \
+		$(HELM) upgrade --install --create-namespace --namespace $(TEST_NAMESPACE) --wait $$dep oci://quay.io/kubedoopcharts/$$dep --version $(VERSION); \
 	done
 endif
 


### PR DESCRIPTION
resolve #208

## Summary by Sourcery

Switch helm chart installation to use OCI registry in CI workflows and Makefile, replacing the previous HTTP helm repo.

Enhancements:
- Replaced HTTP helm repo installs with OCI registry references and version pinning in helm upgrade/install commands

Build:
- Adjusted Makefile's helm-install-depends target to install charts from the OCI registry with version specification

CI:
- Updated chart-lint-test.yml and release.yml workflows to use OCI registry paths and removed 'helm repo add' steps