### PR TITLE
fix: update image loading command to use VERSION variable instead of env.VERSION

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -88,7 +88,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           make docker-build
-          kind load docker-image quay.io/zncdatadev/spark-k8s-operator:${{ env.VERSION }}
+          kind load docker-image quay.io/zncdatadev/spark-k8s-operator:$VERSION
 
 
       - name: Run chart-testing (install)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
         if: steps.check-changes.outputs.changed == 'true'
         run: |
           make docker-build
-          kind load docker-image quay.io/zncdatadev/spark-k8s-operator:${{ env.VERSION }}
+          kind load docker-image quay.io/zncdatadev/spark-k8s-operator:$VERSION
 
       - name: Run chart-testing (install)
         id: ct-test


### PR DESCRIPTION
## Summary by Sourcery

Correct the Docker image loading command in GitHub Actions to use the VERSION shell variable instead of GitHub Actions env.VERSION syntax

Bug Fixes:
- Update chart-lint-test workflow to use \$VERSION for Docker image loading
- Update release workflow to use \$VERSION for Docker image loading